### PR TITLE
break before running undefined file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ switch (cmd) {
         logErrors(hlFile);
         console.log(`Compiled "${argv.file}"`);
         generate(hlFile);
+        if (!!!hlFile.text) { break; }
         console.log(`Running "${argv.file}"\n`);
         runScript(outPath(argv.file), function (err) {
             if (err) throw err;


### PR DESCRIPTION
If the file we are trying to run has nothing in it then we can just break before running it. 

This occurs when the compiled file has no action taken and generates no code.