### PR TITLE
chore: revert antrl4 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "dependencies": {
         "@hpcc-js/dataflow": "8.1.2",
         "@hpcc-js/util": "2.46.2",
-        "antlr4": "4.9.3",
+        "antlr4": "~4.7.0",
         "yargs": "16.2.0"
     },
     "devDependencies": {
-        "@types/antlr4": "4.7.2",
+        "@types/antlr4": "~4.7.0",
         "@types/chai": "4.3.0",
         "@types/mocha": "9.1.0",
         "@types/node": "16.11.26",


### PR DESCRIPTION
ANtlr4 version 4.9.0 seems to have internal issues issues 

https://github.com/antlr/antlr4/issues/2968

Reverting to initial version ~4.7.0 which resolves to 4.7.2 and is fine for me locally.

@AlexSmith Once this is merged;
1. Pull changes
2. Remove node_modules and package lock
3. Run `npm i`