### PR TITLE
GitHub pages observablemd

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,14 +1,32 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset='utf-8'>
   <meta http-equiv='X-UA-Compatible' content='IE=edge'>
   <title>Hoshie Lang Demo</title>
   <meta name='viewport' content='width=device-width, initial-scale=1'>
   <link rel='stylesheet' type='text/css' media='screen' href='pages.css'>
-  <script src='pages.js'></script>
+  <script type="importmap">
+    {
+        "imports": {
+            "@hpcc-js/observable-md": "https://cdn.skypack.dev/@hpcc-js/observable-md",
+            "@hpcc-js/codemirror": "https://cdn.skypack.dev/@hpcc-js/codemirror",
+            "lit": "https://cdn.jsdelivr.net/gh/lit/dist@2/all/lit-all.min.js"
+        }
+    }
+</script>
+  <script type="module" src='pages.js'></script>
 </head>
+
 <body>
   <p>Hoshie Lang</p>
+  <article class="container">
+    <section id="editor">
+    </section>
+    <section id="render">
+    </section>
+  </article>
 </body>
+
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+  <title>Hoshie Lang Demo</title>
+  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <link rel='stylesheet' type='text/css' media='screen' href='pages.css'>
+  <script src='pages.js'></script>
+</head>
+<body>
+  <p>Hoshie Lang</p>
+</body>
+</html>

--- a/docs/pages.css
+++ b/docs/pages.css
@@ -1,0 +1,16 @@
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+#editor {
+  padding: 10px;
+  margin-top: 10px;
+} 
+
+#render {
+  width: 100%;
+  height: 500px;
+  border: 1px solid #ccc!important;
+  border-radius: 16px;
+}

--- a/docs/pages.js
+++ b/docs/pages.js
@@ -1,0 +1,65 @@
+import { Observable } from "@hpcc-js/observable-md";
+// import { LitElement, html } from "lit";
+import { ECLEditor } from "@hpcc-js/codemirror";
+
+// Init initial state
+const code = `\
+//  Short form function
+add = (number a, number b) => a + b;
+
+//  Long form function
+add2 = (number a, number b) => {
+    return a + b;
+};
+
+//  Function with locally scoped declarations
+add3 = (number a, number b) => {
+    tmpA = a;
+    tmpB = b;
+    tmp = tmpA + tmpB;
+    return tmp;
+};
+
+add(1, 2);
+add2(1, 2);
+add3(1, 2);
+
+//  Function with default value support
+join = (string a = "Hello", string b = "World") => a + " " + b;
+
+join();
+join("Goodbye");
+join(, "Earth");
+join("Goodbye", "Earth");
+`;
+
+// Initialise app
+var editor = new ECLEditor()
+  .ecl(code)
+  .target("editor")
+  .render()
+  ;
+
+var app = new Observable()
+.target("render")
+.showValues(true)
+.mode("omd")
+.text("")
+;
+
+// Utils
+const doResize = () => {
+  if (app) {
+    app
+      .resize()
+      .lazyRender()
+      ;
+  }
+};
+
+// Main
+doResize();
+
+  // get codemirror content as .ho
+  // compile .ho text
+  // render the compiled js in obm


### PR DESCRIPTION
@GordonSmith Looking at including a demo page here.
See https://aherneyeldarb.github.io/hoshie-lang/, for WIP until we merge this into Alex's main.

Is there a better way to architect this ? 


Will need to include the built files in this directory somewhere I guess as I'm using raw js/html and not ts with webpack or some buildstep. However, as it stands we don't have a method of supplying string literal only `HLFileScope` right? So we will need to export some;
```ts
function generate( text:string ) : string { 
...
}
```
This will return the Javascript that we pass into `runScript`. We can pass this JS directly to observablemd. 

Not sure if we will run into issues as browser doesn't have native require. Is there a way to pass the current context into the observablemd ? So this kind of thing is possible;
```js
import * as df from "@hpcc-js/dataflow";
var app = new Observable()
.target("render")
.showValues(true)
.mode("omd")
.text("" + 
"``` \n" + 
"df.filter(....) \n" +
"``` \n") 
;
```

